### PR TITLE
feat: Ingress 기반 ALB 배포 및 spring-active 서비스 ClusterIP 전환

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,3 +73,19 @@ jobs:
           kubectl apply -f k8s/spring-preview.yaml
           kubectl apply -f k8s/argo-rollouts-rbac.yaml
           kubectl apply -f k8s/rollout.yaml
+          kubectl apply -f k8s/spring-ingress.yaml
+
+      - name: Show Ingress ALB URL
+        run: |
+          INGRESS_HOST=$(kubectl get ingress spring-ingress -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
+          echo "::set-output name=alb_url::http://$INGRESS_HOST"
+        id: ingress
+
+      - name: Comment Ingress URL on PR
+        if: github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          message: |
+            🚀 **Ingress ALB Endpoint**
+            Your app is deployed and accessible at:
+            [${{ steps.ingress.outputs.alb_url }}](${{ steps.ingress.outputs.alb_url }})

--- a/k8s/spring-active.yaml
+++ b/k8s/spring-active.yaml
@@ -10,4 +10,4 @@ spec:
   ports:
     - port: 80
       targetPort: 8080
-  type: LoadBalancer
+  type: ClusterIP

--- a/k8s/spring-ingress.yaml
+++ b/k8s/spring-ingress.yaml
@@ -1,0 +1,42 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: spring-ingress
+  namespace: default
+  annotations:
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/group.name: spring-app
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}]'
+    alb.ingress.kubernetes.io/healthcheck-path: /actuator/health
+    alb.ingress.kubernetes.io/backend-protocol: HTTP
+    alb.ingress.kubernetes.io/success-codes: "200-399"
+    alb.ingress.kubernetes.io/load-balancer-attributes: routing.http.drop_invalid_header_fields.enabled=true
+    kubernetes.io/ingress.class: alb
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: spring-active
+                port:
+                  number: 80
+
+          - path: /preview
+            pathType: Prefix
+            backend:
+              service:
+                name: spring-preview
+                port:
+                  number: 80
+
+          - path: /grafana
+            pathType: Prefix
+            backend:
+              service:
+                name: grafana
+                port:
+                  number: 3000


### PR DESCRIPTION
- spring-active 서비스 타입을 LoadBalancer → ClusterIP로 변경하여 ALB 중복 생성을 방지
- GitHub Actions 워크플로우에 Ingress 리소스 배포 단계 추가
- 배포 후 Ingress ALB 주소를 PR에 자동 댓글로 표시하는 기능 추가