### PR TITLE
refactor: ALB Ingress scheme을 internet-facing → internal로 변경

### DIFF
--- a/k8s/spring-ingress.yaml
+++ b/k8s/spring-ingress.yaml
@@ -4,7 +4,7 @@ metadata:
   name: spring-ingress
   namespace: default
   annotations:
-    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/scheme: internal
     alb.ingress.kubernetes.io/target-type: ip
     alb.ingress.kubernetes.io/group.name: spring-app
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}]'


### PR DESCRIPTION
- 외부 공개형 ALB에서 내부 통신 전용 internal ALB로 리팩토링
- VPC 외부에서는 직접 접근할 수 없으며, Bastion 또는 VPC 내부 서비스에서만 접근 가능